### PR TITLE
add port instance method to set/get the port number to use

### DIFF
--- a/lib/Net/LDNS.pm
+++ b/lib/Net/LDNS.pm
@@ -120,9 +120,14 @@ Get and optionally set the number of retries.
 
 Get and optionally set the number of seconds between retries.
 
+=item port($port)
+
+Get and optionally set the destination port for requests.
+
 =item edns_size($size)
 
 Get and optionally set the EDNS0 UDP maximum size.
+
 
 =item axfr( $domain, $callback, $class )
 

--- a/lib/Net/LDNS/Packet.pm
+++ b/lib/Net/LDNS/Packet.pm
@@ -73,6 +73,8 @@ will be thrown.
 Returns the packet id number. If given an argument, sets the ID value to that
 value.
 
+=item qr()
+
 =item aa()
 
 =item tc()

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -416,6 +416,18 @@ edns_size(obj,...)
     OUTPUT:
         RETVAL
 
+U16
+port(obj,...)
+    Net::LDNS obj;
+    CODE:
+        if( items > 1 )
+        {
+            ldns_resolver_set_port(obj, (U16)SvIV(ST(1)));
+        }
+        RETVAL = ldns_resolver_port(obj);
+    OUTPUT:
+        RETVAL
+
 SV *
 name2addr(obj,name)
     Net::LDNS obj;


### PR DESCRIPTION
I needed a way to ask question to a (test) resolver on another port, so i added a port method to do that.