### PR TITLE
Better resolution for querytime, now returns Time::Hires compatible floats

### DIFF
--- a/include/ldns/packet.h
+++ b/include/ldns/packet.h
@@ -240,7 +240,7 @@ struct ldns_struct_pkt
         /** Timestamp of the time the packet was sent or created */
 	struct timeval timestamp;
 	/** The duration of the query this packet is an answer to */
-	uint32_t _querytime;
+        double _querytime;
 	/** The size of the wire format of the packet in octets */
 	size_t _size;
 	/** Optional tsig rr */
@@ -398,12 +398,20 @@ ldns_rdf *ldns_pkt_answerfrom(const ldns_pkt *p);
  * \return the timestamp
  */
 struct timeval ldns_pkt_timestamp(const ldns_pkt *p);
+
 /**
  * Return the packet's querytime
  * \param[in] p the packet
  * \return the querytime
  */
 uint32_t ldns_pkt_querytime(const ldns_pkt *p);
+
+/**
+ * Return the packet's querytime
+ * \param[in] p the packet
+ * \return the querytime
+ */
+double ldns_pkt_fquerytime(const ldns_pkt *p);
 
 /**
  * Return the packet's size in bytes
@@ -621,12 +629,21 @@ void ldns_pkt_set_arcount(ldns_pkt *p, uint16_t c);
  * \param[in] r the address
  */
 void ldns_pkt_set_answerfrom(ldns_pkt *p, ldns_rdf *r);
+
 /**
  * Set the packet's query time
  * \param[in] p the packet
  * \param[in] t the querytime in msec
  */
 void ldns_pkt_set_querytime(ldns_pkt *p, uint32_t t);
+
+/**
+ * Set the packet's query time
+ * \param[in] p the packet
+ * \param[in] t the querytime in msec
+ */
+void ldns_pkt_set_fquerytime(ldns_pkt *p, double t);
+
 /**
  * Set the packet's size
  * \param[in] p the packet

--- a/lib/Net/LDNS/Packet.pm
+++ b/lib/Net/LDNS/Packet.pm
@@ -128,7 +128,7 @@ thus rather pointless until such time as EDNS1 is defined.
 =item querytime([$value])
 
 Returns the time the query this packet is the answer to took to execute, in
-milliseconds. If given a value, sets the querytime to that value.
+(fractional) seconds. If given a value, sets the querytime to that value.
 
 =item answerfrom($ipaddr)
 

--- a/src/LDNS.xs
+++ b/src/LDNS.xs
@@ -940,14 +940,14 @@ packet_size(obj)
     OUTPUT:
         RETVAL
 
-U32
+double
 packet_querytime(obj,...)
     Net::LDNS::Packet obj;
     CODE:
 		if ( items > 1 ) {
-			ldns_pkt_set_querytime(obj, (U32)SvIV(ST(1)));
+			ldns_pkt_set_fquerytime(obj, SvNV(ST(1)));
 		}
-        RETVAL = ldns_pkt_querytime(obj);
+        RETVAL = ldns_pkt_fquerytime(obj);
     OUTPUT:
         RETVAL
 

--- a/src/ldns/net.c
+++ b/src/ldns/net.c
@@ -595,9 +595,9 @@ ldns_send_buffer(ldns_pkt **result, ldns_resolver *r, ldns_buffer *qb, ldns_rdf 
 		gettimeofday(&tv_e, NULL);
 
 		if (reply) {
-			ldns_pkt_set_querytime(reply, (uint32_t)
-				((tv_e.tv_sec - tv_s.tv_sec) * 1000) +
-				(tv_e.tv_usec - tv_s.tv_usec) / 1000);
+			ldns_pkt_set_fquerytime(reply, (double)
+				(tv_e.tv_sec - tv_s.tv_sec) +
+				(tv_e.tv_usec - tv_s.tv_usec) / 1000000.0);
 			ldns_pkt_set_answerfrom(reply,
 					ldns_rdf_clone(ns_array[i]));
 			ldns_pkt_set_timestamp(reply, tv_s);

--- a/src/ldns/packet.c
+++ b/src/ldns/packet.c
@@ -187,6 +187,12 @@ ldns_pkt_size(const ldns_pkt *packet)
 uint32_t 
 ldns_pkt_querytime(const ldns_pkt *packet)
 {
+	return (uint32_t) packet->_querytime * 1000;
+}
+
+double
+ldns_pkt_fquerytime(const ldns_pkt *packet)
+{
 	return packet->_querytime;
 }
 
@@ -571,6 +577,12 @@ ldns_pkt_set_arcount(ldns_pkt *packet, uint16_t arcount)
 void
 ldns_pkt_set_querytime(ldns_pkt *packet, uint32_t time) 
 {
+	packet->_querytime = (time / 1000.0);
+}
+
+void
+ldns_pkt_set_fquerytime(ldns_pkt *packet, double time) 
+{
 	packet->_querytime = time;
 }
 
@@ -768,7 +780,7 @@ ldns_pkt_new(void)
 	ldns_pkt_set_rcode(packet, 0);
 	ldns_pkt_set_id(packet, 0); 
 	ldns_pkt_set_size(packet, 0);
-	ldns_pkt_set_querytime(packet, 0);
+	ldns_pkt_set_fquerytime(packet, 0.0);
 	memset(&packet->timestamp, 0, sizeof(packet->timestamp));
 	ldns_pkt_set_answerfrom(packet, NULL);
 	ldns_pkt_set_section_count(packet, LDNS_SECTION_QUESTION, 0);
@@ -1132,7 +1144,7 @@ ldns_pkt_clone(const ldns_pkt *pkt)
 		ldns_pkt_set_answerfrom(new_pkt,
 			ldns_rdf_clone(ldns_pkt_answerfrom(pkt)));
 	ldns_pkt_set_timestamp(new_pkt, ldns_pkt_timestamp(pkt));
-	ldns_pkt_set_querytime(new_pkt, ldns_pkt_querytime(pkt));
+	ldns_pkt_set_fquerytime(new_pkt, ldns_pkt_fquerytime(pkt));
 	ldns_pkt_set_size(new_pkt, ldns_pkt_size(pkt));
 	ldns_pkt_set_tsig(new_pkt, ldns_rr_clone(ldns_pkt_tsig(pkt)));
 	


### PR DESCRIPTION
Hi,

Not sure if you want something like this, but I needed better querytime resolution (because my test-ns usually answers within 1 ms), so I added a fquerytime call to the embedded ldns library and made the xs part use that.

Gr,
Wieger