### PR TITLE
Make it possible to run tests without network

### DIFF
--- a/t/axfr.t
+++ b/t/axfr.t
@@ -3,23 +3,27 @@ use Test::Fatal;
 
 BEGIN { use_ok( 'Net::LDNS' ) }
 
-my $res = Net::LDNS->new( '46.21.100.115' );
-my $res2 = Net::LDNS->new( '192.36.144.107' );
+SKIP: {
+    skip 'no network', 3 if $ENV{TEST_NO_NETWORK};
 
-my $counter = 0;
-my $return = $res->axfr( 'cyberpomo.com',
-    sub {
-        my ($rr) = @_;
-        $counter += 1;
-        if ($rr->type eq 'CNAME') {
-            return 0;
-        } else {
-            return 1;
-        }
-    });
-ok(!$return, 'Terminated early');
-ok(($counter > 1), 'Saw more than one entry (' . $counter . ')');
+    my $res = Net::LDNS->new( '46.21.100.115' );
+    my $res2 = Net::LDNS->new( '192.36.144.107' );
 
-like( exception { $res2->axfr( 'iis.se', sub { return 1 })}, qr/NOTAUTH/, 'Expected exception');
+    my $counter = 0;
+    my $return = $res->axfr( 'cyberpomo.com',
+        sub {
+            my ($rr) = @_;
+            $counter += 1;
+            if ($rr->type eq 'CNAME') {
+                return 0;
+            } else {
+                return 1;
+            }
+        });
+    ok(!$return, 'Terminated early');
+    ok(($counter > 1), 'Saw more than one entry (' . $counter . ')');
+
+    like( exception { $res2->axfr( 'iis.se', sub { return 1 })}, qr/NOTAUTH/, 'Expected exception');
+}
 
 done_testing;

--- a/t/dnssec.t
+++ b/t/dnssec.t
@@ -63,11 +63,15 @@ my $nsec3 = Net::LDNS::RR->new('NR2E513KM693MBTNVHH56ENF54F886T0.com. 86400 IN N
 isa_ok($nsec3, 'Net::LDNS::RR::NSEC3');
 ok($nsec3->covers('xx-example.com'), 'Covers xx-example.com');
 
-$res = Net::LDNS->new( '212.247.7.228' );
-$res->dnssec( 1 );
-my $p1 = eval { $res->query('www.iis.se', 'A') };
 SKIP: {
+    skip 'no network', 3 if $ENV{TEST_NO_NETWORK};
+
+    $res = Net::LDNS->new( '212.247.7.228' );
+    $res->dnssec( 1 );
+    my $p1 = eval { $res->query('www.iis.se', 'A') };
+
     skip 'Remote server not responding', 3 if not $p1;
+
     ok( $p1->needs_edns, 'Needs EDNS0');
     ok( $p1->has_edns, 'Alias is there');
     ok( ($p1->edns_size > 0), 'EDNS0 size larger than zero' );

--- a/t/netldns.t
+++ b/t/netldns.t
@@ -7,88 +7,92 @@ BEGIN { use_ok( 'Net::LDNS' ) }
 my $lib_v = version->parse(Net::LDNS::lib_version());
 ok( $lib_v >= v1.6.16, 'ldns version at least 1.6.16' );
 
-my $s = Net::LDNS->new( '8.8.8.8' );
-isa_ok( $s, 'Net::LDNS' );
-my $p = $s->query( 'nic.se', 'MX' );
-isa_ok( $p, 'Net::LDNS::Packet' );
-is( $p->rcode, 'NOERROR', 'expected rcode' );
+SKIP: {
+    skip 'no network', 59 if $ENV{TEST_NO_NETWORK};
 
-my $p2 = $s->query( 'iis.se', 'NS', 'IN' );
-isa_ok( $p2, 'Net::LDNS::Packet' );
-is( $p2->rcode, 'NOERROR' );
-is( $p2->opcode, 'QUERY', 'expected opcode' );
-my $pround = Net::LDNS::Packet->new_from_wireformat( $p2->wireformat );
-isa_ok( $pround, 'Net::LDNS::Packet' );
-is( $pround->opcode, $p2->opcode, 'roundtrip opcode OK' );
-is( $pround->rcode,  $p2->rcode,  'roundtrip rcode OK' );
+    my $s = Net::LDNS->new( '8.8.8.8' );
+    isa_ok( $s, 'Net::LDNS' );
+    my $p = $s->query( 'nic.se', 'MX' );
+    isa_ok( $p, 'Net::LDNS::Packet' );
+    is( $p->rcode, 'NOERROR', 'expected rcode' );
 
-ok( $p2->id() > 0, 'packet ID set' );
-ok( $p2->qr(),     'QR bit set' );
-ok( !$p2->aa(),    'AA bit not set' );
-ok( !$p2->tc(),    'TC bit not set' );
-ok( $p2->rd(),     'RD bit set' );
-ok( !$p2->cd(),    'CD bit not set' );
-ok( $p2->ra(),     'RA bit set' );
-ok( !$p2->ad(),    'AD bit not set' );
-ok( !$p2->do(),    'DO bit not set' );
+    my $p2 = $s->query( 'iis.se', 'NS', 'IN' );
+    isa_ok( $p2, 'Net::LDNS::Packet' );
+    is( $p2->rcode, 'NOERROR' );
+    is( $p2->opcode, 'QUERY', 'expected opcode' );
+    my $pround = Net::LDNS::Packet->new_from_wireformat( $p2->wireformat );
+    isa_ok( $pround, 'Net::LDNS::Packet' );
+    is( $pround->opcode, $p2->opcode, 'roundtrip opcode OK' );
+    is( $pround->rcode,  $p2->rcode,  'roundtrip rcode OK' );
 
-ok( $p2->querytime > 0 );
-is( $p2->answerfrom, '8.8.8.8', 'expected answerfrom' );
-$p2->answerfrom( '1.2.3.4' );
-is( $p2->answerfrom, '1.2.3.4', 'setting answerfrom works' );
+    ok( $p2->id() > 0, 'packet ID set' );
+    ok( $p2->qr(),     'QR bit set' );
+    ok( !$p2->aa(),    'AA bit not set' );
+    ok( !$p2->tc(),    'TC bit not set' );
+    ok( $p2->rd(),     'RD bit set' );
+    ok( !$p2->cd(),    'CD bit not set' );
+    ok( $p2->ra(),     'RA bit set' );
+    ok( !$p2->ad(),    'AD bit not set' );
+    ok( !$p2->do(),    'DO bit not set' );
 
-ok($p2->timestamp > 0, 'has a timestamp to begin with');
-$p2->timestamp( 4711 );
-is( $p2->timestamp, 4711, 'setting timestamp works' );
-$p2->timestamp( 4711.4711 );
-ok( $p2->timestamp - 4711.4711 < 0.0001, 'setting timestamp works with microseconds too' );
+    ok( $p2->querytime > 0 );
+    is( $p2->answerfrom, '8.8.8.8', 'expected answerfrom' );
+    $p2->answerfrom( '1.2.3.4' );
+    is( $p2->answerfrom, '1.2.3.4', 'setting answerfrom works' );
 
-eval { $s->query( 'nic.se', 'gurksallad', 'CH' ) };
-like( $@, qr/Unknown RR type: gurksallad/ );
+    ok($p2->timestamp > 0, 'has a timestamp to begin with');
+    $p2->timestamp( 4711 );
+    is( $p2->timestamp, 4711, 'setting timestamp works' );
+    $p2->timestamp( 4711.4711 );
+    ok( $p2->timestamp - 4711.4711 < 0.0001, 'setting timestamp works with microseconds too' );
 
-eval { $s->query( 'nic.se', 'SOA', 'gurksallad' ) };
-like( $@, qr/Unknown RR class: gurksallad/ );
+    eval { $s->query( 'nic.se', 'gurksallad', 'CH' ) };
+    like( $@, qr/Unknown RR type: gurksallad/ );
 
-eval { $s->query( 'nic.se', 'soa', 'IN' ) };
-ok( !$@ );
+    eval { $s->query( 'nic.se', 'SOA', 'gurksallad' ) };
+    like( $@, qr/Unknown RR class: gurksallad/ );
 
-my @answer = $p2->answer;
-is( scalar( @answer ), 3, 'expected number of NS records in answer' );
-my %known_ns = map { $_ => 1 } qw[ns.nic.se. i.ns.se. ns3.nic.se.];
-foreach my $rr ( @answer ) {
-    isa_ok( $rr, 'Net::LDNS::RR::NS' );
-    is( lc($rr->owner), 'iis.se.', 'expected owner name' );
-    ok( $rr->ttl > 0, 'positive TTL (' . $rr->ttl . ')' );
-    is( $rr->type,  'NS', 'type is NS' );
-    is( $rr->class, 'IN', 'class is IN' );
-    ok( $known_ns{ lc($rr->nsdname) }, 'known nsdname (' . $rr->nsdname . ')' );
+    eval { $s->query( 'nic.se', 'soa', 'IN' ) };
+    ok( !$@ );
+
+    my @answer = $p2->answer;
+    is( scalar( @answer ), 3, 'expected number of NS records in answer' );
+    my %known_ns = map { $_ => 1 } qw[ns.nic.se. i.ns.se. ns3.nic.se.];
+    foreach my $rr ( @answer ) {
+        isa_ok( $rr, 'Net::LDNS::RR::NS' );
+        is( lc($rr->owner), 'iis.se.', 'expected owner name' );
+        ok( $rr->ttl > 0, 'positive TTL (' . $rr->ttl . ')' );
+        is( $rr->type,  'NS', 'type is NS' );
+        is( $rr->class, 'IN', 'class is IN' );
+        ok( $known_ns{ lc($rr->nsdname) }, 'known nsdname (' . $rr->nsdname . ')' );
+    }
+
+    my %known_mx = map { $_ => 1 } qw[mx1.iis.se. mx2.iis.se. ];
+    foreach my $rr ( $p->answer ) {
+        is( $rr->preference, 10, 'expected MX preference' );
+        ok( $known_mx{ lc($rr->exchange) }, 'known MX exchange (' . $rr->exchange . ')' );
+    }
+
+    my $lroot = Net::LDNS->new( '199.7.83.42' );
+    my $se = $lroot->query( 'se', 'NS' );
+
+    is( scalar( $se->question ),   1,  'one question' );
+    is( scalar( $se->answer ),     0,  'zero answers' );
+    is( scalar( $se->authority ),  9,  'nine authority' );
+    my $add = scalar( $se->additional );
+    ok( $add == 16 || $add == 15, 'sixteen additional' );
+
+    my $rr = Net::LDNS::RR->new_from_string(
+        'se. 172800	IN	SOA	catcher-in-the-rye.nic.se. registry-default.nic.se. 2013111305 1800 1800 864000 7200' );
+    my $rr2 =
+      Net::LDNS::RR->new( 'se.			172800	IN	TXT	"SE zone update: 2013-11-13 15:08:28 +0000 (EPOCH 1384355308) (auto)"' );
+    ok( $se->unique_push( 'answer', $rr ), 'unique_push returns ok' );
+    is( $se->answer, 1, 'one record in answer section' );
+    ok( !$se->unique_push( 'answer', $rr ), 'unique_push returns false' );
+    is( $se->answer, 1, 'still one record in answer section' );
+    ok( $se->unique_push( 'ansWer', $rr2 ), 'unique_push returns ok again' );
+    is( $se->answer, 2, 'two records in answer section' );
 }
-
-my %known_mx = map { $_ => 1 } qw[mx1.iis.se. mx2.iis.se. ];
-foreach my $rr ( $p->answer ) {
-    is( $rr->preference, 10, 'expected MX preference' );
-    ok( $known_mx{ lc($rr->exchange) }, 'known MX exchange (' . $rr->exchange . ')' );
-}
-
-my $lroot = Net::LDNS->new( '199.7.83.42' );
-my $se = $lroot->query( 'se', 'NS' );
-
-is( scalar( $se->question ),   1,  'one question' );
-is( scalar( $se->answer ),     0,  'zero answers' );
-is( scalar( $se->authority ),  9,  'nine authority' );
-my $add = scalar( $se->additional );
-ok( $add == 16 || $add == 15, 'sixteen additional' );
-
-my $rr = Net::LDNS::RR->new_from_string(
-    'se. 172800	IN	SOA	catcher-in-the-rye.nic.se. registry-default.nic.se. 2013111305 1800 1800 864000 7200' );
-my $rr2 =
-  Net::LDNS::RR->new( 'se.			172800	IN	TXT	"SE zone update: 2013-11-13 15:08:28 +0000 (EPOCH 1384355308) (auto)"' );
-ok( $se->unique_push( 'answer', $rr ), 'unique_push returns ok' );
-is( $se->answer, 1, 'one record in answer section' );
-ok( !$se->unique_push( 'answer', $rr ), 'unique_push returns false' );
-is( $se->answer, 1, 'still one record in answer section' );
-ok( $se->unique_push( 'ansWer', $rr2 ), 'unique_push returns ok again' );
-is( $se->answer, 2, 'two records in answer section' );
 
 my $made = Net::LDNS::Packet->new( 'foo.com', 'SOA', 'IN' );
 isa_ok( $made, 'Net::LDNS::Packet' );

--- a/t/optrr.t
+++ b/t/optrr.t
@@ -2,13 +2,16 @@ use Test::More;
 
 use_ok('Net::LDNS');
 
-my $r = Net::LDNS->new('192.5.6.30');
-isa_ok($r, 'Net::LDNS');
-ok($r->dnssec(1), 'DO flag set.');
-
-my $p = $r->query('net', 'SOA');
 SKIP: {
-    skip "Remote server not responding." if not $p;
+    skip 'no network', 8 if $ENV{TEST_NO_NETWORK};
+
+    my $r = Net::LDNS->new('192.5.6.30');
+    isa_ok($r, 'Net::LDNS');
+    ok($r->dnssec(1), 'DO flag set.');
+
+    my $p = $r->query('net', 'SOA');
+
+    skip 'Remote server not responding.', 6 if not $p;
     isa_ok($p, 'Net::LDNS::Packet');
 
     my $rr = $p->opt_rr;

--- a/t/packet.t
+++ b/t/packet.t
@@ -28,5 +28,4 @@ is($p->answerfrom, undef, 'No answerfrom');
 $p->answerfrom('127.0.0.1');
 is($p->answerfrom, '127.0.0.1', 'Localhost');
 
-
 done_testing();

--- a/t/regression.t
+++ b/t/regression.t
@@ -6,8 +6,12 @@ use warnings;
 
 BEGIN { use_ok("Net::LDNS")}
 
-my $s = Net::LDNS->new( '8.8.8.8' );
-isa_ok( $s, 'Net::LDNS' );
-like( exception { $s->query( 'xx--example..', 'A' ) }, qr/Invalid domain name: xx--example../, 'Died on invalid name');
+SKIP: {
+    skip 'no network', 2 if $ENV{TEST_NO_NETWORK};
+
+    my $s = Net::LDNS->new( '8.8.8.8' );
+    isa_ok( $s, 'Net::LDNS' );
+    like( exception { $s->query( 'xx--example..', 'A' ) }, qr/Invalid domain name: xx--example../, 'Died on invalid name');
+}
 
 done_testing;

--- a/t/resolver.t
+++ b/t/resolver.t
@@ -2,77 +2,89 @@ use Test::More;
 
 use Net::LDNS;
 
-my $r = Net::LDNS->new( '8.8.8.8' );
+SKIP: {
+    skip 'no network', 20 if $ENV{TEST_NO_NETWORK};
 
-$r->recurse( 0 );
-ok( !$r->recurse, 'recursive off' );
-$r->recurse( 1 );
-ok( $r->recurse, 'recursive on' );
+    my $r = Net::LDNS->new( '8.8.8.8' );
 
-$r->retrans( 17 );
-is( $r->retrans, 17, 'retrans set' );
+    $r->recurse( 0 );
+    ok( !$r->recurse, 'recursive off' );
+    $r->recurse( 1 );
+    ok( $r->recurse, 'recursive on' );
 
-$r->retry( 17 );
-is( $r->retry, 17, 'retry set' );
+    $r->retrans( 17 );
+    is( $r->retrans, 17, 'retrans set' );
 
-$r->debug( 1 );
-ok( $r->debug, 'debug set' );
-$r->debug( 0 );
-ok( !$r->debug, 'debug unset' );
+    $r->retry( 17 );
+    is( $r->retry, 17, 'retry set' );
 
-$r->dnssec( 1 );
-ok( $r->dnssec, 'dnssec set' );
-$r->dnssec( 0 );
-ok( !$r->dnssec, 'dnssec unset' );
+    $r->debug( 1 );
+    ok( $r->debug, 'debug set' );
+    $r->debug( 0 );
+    ok( !$r->debug, 'debug unset' );
 
-$r->cd( 1 );
-ok( $r->cd, 'dnssec set' );
-$r->cd( 0 );
-ok( !$r->cd, 'dnssec unset' );
+    $r->dnssec( 1 );
+    ok( $r->dnssec, 'dnssec set' );
+    $r->dnssec( 0 );
+    ok( !$r->dnssec, 'dnssec unset' );
 
-$r->usevc( 1 );
-ok( $r->usevc, 'usevc set' );
-$r->usevc( 0 );
-ok( !$r->usevc, 'usevc unset' );
+    $r->cd( 1 );
+    ok( $r->cd, 'dnssec set' );
+    $r->cd( 0 );
+    ok( !$r->cd, 'dnssec unset' );
 
-$r->igntc( 1 );
-ok( $r->igntc, 'igntc set' );
-$r->igntc( 0 );
-ok( !$r->igntc, 'igntc unset' );
+    $r->usevc( 1 );
+    ok( $r->usevc, 'usevc set' );
+    $r->usevc( 0 );
+    ok( !$r->usevc, 'usevc unset' );
 
-$r->edns_size( 4711 );
-is($r->edns_size, 4711 , 'ENDS0 UDP size set');
-$r->edns_size( 0 );
-is($r->edns_size, 0 , 'ENDS0 UDP size set to zero');
+    $r->igntc( 1 );
+    ok( $r->igntc, 'igntc set' );
+    $r->igntc( 0 );
+    ok( !$r->igntc, 'igntc unset' );
 
-is($r->timeout, 5, 'Expected default timeout');
-$r->timeout(3.33);
-ok(($r->timeout - 3.33) < 0.01, 'Expected set timeout');
+    $r->edns_size( 4711 );
+    is($r->edns_size, 4711 , 'ENDS0 UDP size set');
+    $r->edns_size( 0 );
+    is($r->edns_size, 0 , 'ENDS0 UDP size set to zero');
 
-my $addr = '192.0.2.1'; # Reserved RFC5737
-ok($r->source($addr), "Source set.");
-is($r->source, $addr, 'Source got.');
+    is($r->timeout, 5, 'Expected default timeout');
+    $r->timeout(3.33);
+    ok(($r->timeout - 3.33) < 0.01, 'Expected set timeout');
+
+    my $addr = '192.0.2.1'; # Reserved RFC5737
+    ok($r->source($addr), "Source set.");
+    is($r->source, $addr, 'Source got.');
+}
 
 subtest 'recursion' => sub {
-    my $r = Net::LDNS->new( '8.8.4.4' );
-    my $p1 = $r->query( 'www.iis.se' );
-    is( scalar($p1->answer), 1);
-    $r->recurse(0);
-    my $p2 = $r->query( 'www.nic.se' );
-    is( scalar($p2->answer), 0, 'Got a reply');
-    ok(!$p2->rd, 'RD flag set');
+    SKIP: {
+        skip 'no network', 3 if $ENV{TEST_NO_NETWORK};
+
+        my $r = Net::LDNS->new( '8.8.4.4' );
+        my $p1 = $r->query( 'www.iis.se' );
+        is( scalar($p1->answer), 1);
+        $r->recurse(0);
+        my $p2 = $r->query( 'www.nic.se' );
+        is( scalar($p2->answer), 0, 'Got a reply');
+        ok(!$p2->rd, 'RD flag set');
+    }
 };
 
 subtest 'global' => sub {
-    my $res = new_ok( 'Net::LDNS' );
-    my $p = eval { $res->query( 'www.iis.se' ) } ;
+    SKIP: {
+        skip 'no network', 3 if $ENV{TEST_NO_NETWORK};
 
-    if (not $p) {
-        diag $@;
-    }
-    else {
-        isa_ok( $p, 'Net::LDNS::Packet' );
-        isa_ok( $_, 'Net::LDNS::RR' ) for $p->answer;
+        my $res = new_ok( 'Net::LDNS' );
+        my $p = eval { $res->query( 'www.iis.se' ) } ;
+
+        if (not $p) {
+            diag $@;
+        }
+        else {
+            isa_ok( $p, 'Net::LDNS::Packet' );
+            isa_ok( $_, 'Net::LDNS::RR' ) for $p->answer;
+        }
     }
 };
 
@@ -80,7 +92,7 @@ subtest 'global' => sub {
 #     my $res = Net::LDNS->new( '194.146.106.22' );
 #     my $p   = eval { $res->query( 'www.iis.se' ) };
 #     plan skip_all => 'No response, cannot test' if not $p;
-# 
+#
 #     is( scalar( $p->answer ),     1, 'answer count in scalar context' );
 #     is( scalar( $p->authority ),  3, 'authority count in scalar context' );
 #     is( scalar( $p->additional ), 6, 'additional count in scalar context' );

--- a/t/rrlist.t
+++ b/t/rrlist.t
@@ -3,15 +3,23 @@ use Devel::Peek;
 
 use Net::LDNS;
 
-my $s = Net::LDNS->new( '8.8.8.8' );
-my $p = $s->query( 'iis.se', 'SOA' );
+my $rrl = Net::LDNS::Packet->new( 'foo.com', 'SOA', 'IN' )->all;
+$rrl->pop;
 
-my $rrl = $p->all;
-isa_ok( $rrl, 'Net::LDNS::RRList' );
+SKIP: {
+    skip 'no network', 3 if $ENV{TEST_NO_NETWORK};
 
-is( $rrl->count, 1, 'one RR in list' );
-my $rr = $rrl->pop;
-isa_ok( $rr, 'Net::LDNS::RR::SOA' );
+    my $s = Net::LDNS->new( '8.8.8.8' );
+    my $p = $s->query( 'iis.se', 'SOA' );
+
+    $rrl = $p->all;
+    isa_ok( $rrl, 'Net::LDNS::RRList' );
+
+    is( $rrl->count, 1, 'one RR in list' );
+    my $rr = $rrl->pop;
+    isa_ok( $rr, 'Net::LDNS::RR::SOA' );
+}
+
 is( $rrl->count, 0, 'zero RRs in list' );
 
 my $rr1 = Net::LDNS::RR->new_from_string( 'nic.se IN NS a.ns.se' );

--- a/t/threads.t
+++ b/t/threads.t
@@ -2,8 +2,10 @@ use Test::More;
 
 use_ok('Net::LDNS');
 
-my $can_use_threads = eval 'use threads; 1';
-if ($can_use_threads) {
+SKIP: {
+    my $can_use_threads = eval 'use threads; 1';
+
+    skip 'no network or no threads', 4 if ( $ENV{TEST_NO_NETWORK} || !$can_use_threads );
 
     my $resolver = Net::LDNS->new('8.8.8.8');
     isa_ok($resolver, 'Net::LDNS');
@@ -22,7 +24,6 @@ if ($can_use_threads) {
     } ) for 1..5;
 
     $_->join for threads->list;
-
 }
 
 done_testing;

--- a/t/utils.t
+++ b/t/utils.t
@@ -2,17 +2,21 @@ use Test::More;
 
 BEGIN { use_ok( 'Net::LDNS' ) }
 
-my $res = new_ok( 'Net::LDNS', ['8.8.4.4'] );
+SKIP: {
+    skip 'no network', 5 if $ENV{TEST_NO_NETWORK};
 
-my @addrs = sort $res->name2addr( 'b.ns.se' );
-my $count = $res->name2addr( 'b.ns.se' );
+    my $res = new_ok( 'Net::LDNS', ['8.8.4.4'] );
 
-is_deeply( \@addrs, [ "192.36.133.107", "2001:67c:254c:301::53" ], 'expected addresses' );
-is( $count, 2, 'expected count' );
+    my @addrs = sort $res->name2addr( 'b.ns.se' );
+    my $count = $res->name2addr( 'b.ns.se' );
 
-my @names = sort $res->addr2name( '8.8.8.8' );
-$count = $res->addr2name( '8.8.8.8' );
-is_deeply( [map {lc($_)} @names], ['google-public-dns-a.google.com.'], 'expected names' );
-is( $count, 1, 'expected name count' );
+    is_deeply( \@addrs, [ "192.36.133.107", "2001:67c:254c:301::53" ], 'expected addresses' );
+    is( $count, 2, 'expected count' );
+
+    my @names = sort $res->addr2name( '8.8.8.8' );
+    $count = $res->addr2name( '8.8.8.8' );
+    is_deeply( [map {lc($_)} @names], ['google-public-dns-a.google.com.'], 'expected names' );
+    is( $count, 1, 'expected name count' );
+}
 
 done_testing;


### PR DESCRIPTION
Setting the environment variable `TEST_NO_NETWORK` to true (1) will make t/*.t files skip network related tests. This was needed to build Ubuntu packages on LaunchPad.